### PR TITLE
記錄更動的理由（或錯誤）到 CourseTaskRelation model

### DIFF
--- a/app/models/concerns/course_validation_concern.rb
+++ b/app/models/concerns/course_validation_concern.rb
@@ -3,11 +3,11 @@ module CourseValidationConcern
 
   included do
     def name_valid?(course)
-      !course.name.nil? && !course.name.empty?
+      !course.name.nil? || !course.name.empty?
     end
 
     def lecturer_valid?(course)
-      !course.lecturer.nil? && !course.lecturer.empty?
+      !course.lecturer.nil? || !course.lecturer.empty?
     end
 
     def required_valid?(course)
@@ -15,7 +15,7 @@ module CourseValidationConcern
     end
 
     def credits_valid?(course)
-      !course.credits.nil? && !course.credits.zero?
+      !course.credits.nil?
     end
   end
 end

--- a/app/models/concerns/course_validation_concern.rb
+++ b/app/models/concerns/course_validation_concern.rb
@@ -1,0 +1,21 @@
+module CourseValidationConcern
+  extend ActiveSupport::Concern
+
+  included do
+    def name_valid?(course)
+      !course.name.nil? && !course.name.empty?
+    end
+
+    def lecturer_valid?(course)
+      !course.lecturer.nil? && !course.lecturer.empty?
+    end
+
+    def required_valid?(course)
+      !course.required.nil?
+    end
+
+    def credits_valid?(course)
+      !course.credits.nil? && !course.credits.zero?
+    end
+  end
+end

--- a/app/models/course_error.rb
+++ b/app/models/course_error.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: course_errors
+#
+#  id          :integer          not null, primary key
+#  type        :integer
+#  message     :string
+#  relation_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+class CourseError < ActiveRecord::Base
+  self.inheritance_column = :_type_disabled
+
+  belongs_to :course_task_relation, foreign_key: :relation_id
+end

--- a/app/models/course_error.rb
+++ b/app/models/course_error.rb
@@ -14,4 +14,22 @@ class CourseError < ActiveRecord::Base
   self.inheritance_column = :_type_disabled
 
   belongs_to :course_task_relation, foreign_key: :relation_id
+
+  enum type: [
+    # some required field for course
+    :invalid_lecturer,
+    :invalid_name,
+    :invalid_required,
+    :invalid_credits,
+
+    # no period no course(?)
+    :empty_day,
+    :empty_period,
+    :empty_location,
+
+    # most of the course a least have two periods
+    :only_one_period
+  ]
+
+  validates :type, presence: true
 end

--- a/app/models/course_task_relation.rb
+++ b/app/models/course_task_relation.rb
@@ -18,4 +18,6 @@
 class CourseTaskRelation < ActiveRecord::Base
   belongs_to :version, class_name: 'PaperTrail::Version', foreign_key: :version_id
   belongs_to :crawl_task, foreign_key: :task_id
+
+  has_many   :course_errors, foreign_key: :relation_id
 end

--- a/app/models/course_task_relation.rb
+++ b/app/models/course_task_relation.rb
@@ -16,8 +16,30 @@
 #
 
 class CourseTaskRelation < ActiveRecord::Base
+  include CourseValidationConcern
+
   belongs_to :version, class_name: 'PaperTrail::Version', foreign_key: :version_id
   belongs_to :crawl_task, foreign_key: :task_id
 
   has_many   :course_errors, foreign_key: :relation_id
+
+  after_create :validate_course
+
+  # it's not ActiveRecord Validation as we do not prevent creating a new record
+  # when validation failed. And CourseError is assosiate with CourseTaskRelation
+  # model because we perform check on each PaperTrail::Version.
+  def validate_course
+    course_snapshot = version.reify.nil? ? version.item : version.reify
+
+    course_errors.create(type: :invalid_name)     unless name_valid?(course_snapshot)
+    course_errors.create(type: :invalid_lecturer) unless lecturer_valid?(course_snapshot)
+    course_errors.create(type: :invalid_required) unless required_valid?(course_snapshot)
+    course_errors.create(type: :invalid_credits)  unless credits_valid?(course_snapshot)
+
+    course_errors.create(type: :empty_day) if course_snapshot.day_1.nil?
+    course_errors.create(type: :empty_period) if course_snapshot.period_1.nil?
+    course_errors.create(type: :empty_location) if course_snapshot.location_1.nil?
+
+    course_errors.create(type: :only_one_period) if course_snapshot.day_2.nil? || course_snapshot.period_2.nil? || course_snapshot.location_2.nil?
+  end
 end

--- a/app/models/paper_trail/version.rb
+++ b/app/models/paper_trail/version.rb
@@ -1,16 +1,20 @@
-class PaperTrail::Version < ActiveRecord::Base
-  has_many :course_task_relations, foreign_key: :version_id
-  has_many :course_tasks, through: :course_task_relations, source: :crawl_task
+module PaperTrail
+  class Version < ActiveRecord::Base
+    include PaperTrail::VersionConcern
 
-  # a PaperTrail::Version would only have one corresponding course_task
-  # we build many-to-many relationship in order not to ruin the PaperTrail database schema
-  def course_task
-    course_tasks.first
+    has_many :course_task_relations, foreign_key: :version_id
+    has_many :course_tasks, through: :course_task_relations, source: :crawl_task
+
+    # a PaperTrail::Version would only have one corresponding course_task
+    # we build many-to-many relationship in order not to ruin the PaperTrail database schema
+    def course_task
+      course_tasks.first
+    end
+
+    # delgate course_errors to relation object
+    def course_errors
+      course_task_relations.first.course_errors
+    end
+
   end
-
-  # delgate course_errors to relation object
-  def course_errors
-    course_task_relations.first.course_errors
-  end
-
 end

--- a/app/models/paper_trail/version.rb
+++ b/app/models/paper_trail/version.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: versions
+#
+#  id             :integer          not null, primary key
+#  item_type      :string           not null
+#  item_id        :integer          not null
+#  event          :string           not null
+#  whodunnit      :string
+#  object         :text(1073741823)
+#  created_at     :datetime
+#  object_changes :text(1073741823)
+#
+# Indexes
+#
+#  index_versions_on_item_type_and_item_id  (item_type,item_id)
+#
+
 module PaperTrail
   class Version < ActiveRecord::Base
     include PaperTrail::VersionConcern

--- a/app/models/paper_trail/version.rb
+++ b/app/models/paper_trail/version.rb
@@ -1,0 +1,16 @@
+class PaperTrail::Version < ActiveRecord::Base
+  has_many :course_task_relations, foreign_key: :version_id
+  has_many :course_tasks, through: :course_task_relations, source: :crawl_task
+
+  # a PaperTrail::Version would only have one corresponding course_task
+  # we build many-to-many relationship in order not to ruin the PaperTrail database schema
+  def course_task
+    course_tasks.first
+  end
+
+  # delgate course_errors to relation object
+  def course_errors
+    course_task_relations.first.course_errors
+  end
+
+end

--- a/app/models/paper_trail/version.rb
+++ b/app/models/paper_trail/version.rb
@@ -34,5 +34,9 @@ module PaperTrail
       course_task_relations.first.course_errors
     end
 
+    def course_errors_size
+      course_task_relations.first.course_errors.size
+    end
+
   end
 end

--- a/app/views/crawlers/changes.slim
+++ b/app/views/crawlers/changes.slim
@@ -13,6 +13,7 @@
         tr
           th id
           th event
+          th errors
           th snapshot
           th changeset
 
@@ -21,8 +22,13 @@
             td= version.id
             td= version.event
             td
+              pre
+                - version.course_errors.each do |error|
+                  = "#{error.type}\n"
+            td
               pre = Oj.dump(version.reify,     indent: 4, mode: :compat)
             td
               pre = Oj.dump(version.changeset, indent: 4, mode: :compat)
+
 
     = paginate @versions

--- a/db/migrate/20160808083140_create_course_errors.rb
+++ b/db/migrate/20160808083140_create_course_errors.rb
@@ -1,0 +1,11 @@
+class CreateCourseErrors < ActiveRecord::Migration
+  def change
+    create_table :course_errors do |t|
+      t.integer :type
+      t.string :message
+      t.integer :relation_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160805035816) do
+ActiveRecord::Schema.define(version: 20160808083140) do
 
   create_table "admin_users", force: :cascade do |t|
     t.string   "username",               default: ""
@@ -32,6 +32,14 @@ ActiveRecord::Schema.define(version: 20160805035816) do
   add_index "admin_users", ["email"], name: "index_admin_users_on_email", unique: true
   add_index "admin_users", ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   add_index "admin_users", ["username"], name: "index_admin_users_on_username", unique: true
+
+  create_table "course_errors", force: :cascade do |t|
+    t.integer  "type"
+    t.string   "message"
+    t.integer  "relation_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
 
   create_table "course_task_relations", force: :cascade do |t|
     t.integer  "version_id"

--- a/spec/factories/course_errors.rb
+++ b/spec/factories/course_errors.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: course_errors
+#
+#  id          :integer          not null, primary key
+#  type        :integer
+#  message     :string
+#  relation_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 FactoryGirl.define do
   factory :course_error do
     type 1

--- a/spec/factories/course_errors.rb
+++ b/spec/factories/course_errors.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :course_error do
+    type 1
+    message "MyString"
+    relation_id ""
+  end
+end

--- a/spec/factories/course_task_relations.rb
+++ b/spec/factories/course_task_relations.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: course_task_relations
+#
+#  id         :integer          not null, primary key
+#  version_id :integer
+#  task_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_course_task_relations_on_task_id                 (task_id)
+#  index_course_task_relations_on_task_id_and_version_id  (task_id,version_id) UNIQUE
+#  index_course_task_relations_on_version_id              (version_id)
+#
+
 FactoryGirl.define do
   factory :course_task_relation do
     version_id 1

--- a/spec/factories/crawl_tasks.rb
+++ b/spec/factories/crawl_tasks.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: crawl_tasks
+#
+#  id                :integer          not null, primary key
+#  type              :integer          default(0), not null
+#  finished_at       :datetime
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  course_year       :integer
+#  course_term       :integer
+#  organization_code :string
+#
+# Indexes
+#
+#  index_crawl_tasks_on_course_term        (course_term)
+#  index_crawl_tasks_on_course_year        (course_year)
+#  index_crawl_tasks_on_organization_code  (organization_code)
+#  index_crawl_tasks_on_type               (type)
+#
+
 FactoryGirl.define do
   factory :crawl_task do
     type 1

--- a/spec/models/course_error_spec.rb
+++ b/spec/models/course_error_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CourseError, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/course_error_spec.rb
+++ b/spec/models/course_error_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: course_errors
+#
+#  id          :integer          not null, primary key
+#  type        :integer
+#  message     :string
+#  relation_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 require 'rails_helper'
 
 RSpec.describe CourseError, type: :model do

--- a/spec/models/course_task_relation_spec.rb
+++ b/spec/models/course_task_relation_spec.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: course_task_relations
+#
+#  id         :integer          not null, primary key
+#  version_id :integer
+#  task_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_course_task_relations_on_task_id                 (task_id)
+#  index_course_task_relations_on_task_id_and_version_id  (task_id,version_id) UNIQUE
+#  index_course_task_relations_on_version_id              (version_id)
+#
+
 require 'rails_helper'
 
 RSpec.describe CourseTaskRelation, type: :model do

--- a/spec/models/crawl_task_spec.rb
+++ b/spec/models/crawl_task_spec.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: crawl_tasks
+#
+#  id                :integer          not null, primary key
+#  type              :integer          default(0), not null
+#  finished_at       :datetime
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  course_year       :integer
+#  course_term       :integer
+#  organization_code :string
+#
+# Indexes
+#
+#  index_crawl_tasks_on_course_term        (course_term)
+#  index_crawl_tasks_on_course_year        (course_year)
+#  index_crawl_tasks_on_organization_code  (organization_code)
+#  index_crawl_tasks_on_type               (type)
+#
+
 require 'rails_helper'
 
 RSpec.describe CrawlTask, type: :model do


### PR DESCRIPTION
### Redmine

https://redmine.colorgy.io/issues/342

### Changes

* 建立了 CourseError model，拿來記錄每筆 version 的缺失 => 和 course_task_relation 有著 one to many 的關聯，沒動到 `PaperTrail::Version` model 本身
* 因為與 `CourseTaskRelation` model 關聯，所以 version 的校驗放在該 model 上......似乎有點職責不明呀 😅 
* 之後可以從幾個地方優化，比如在 relation model 加上 counter_cache，就可以直接撈出 errors > 0 的 version......不過也沒有比直接做在 version 本身上來得職責分明，應該直接客製一張表作為 course 的 paper_trail 專用

### Risks

@herber523 @BoyuLin0906 這個 feature 有動到 migration，pull 之後記得 `rake db:migrate`

