### PR TITLE
拿掉 CrawlerRocks 套件相依

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,12 +41,12 @@ gem 'hirb-unicode',  require: false
 # http clients
 gem 'rest-client'
 gem 'httpclient', '~> 2.7'
+gem 'curb'
 
 # encoding
 gem 'iconv'
 
 # crawler helpers
-gem 'crawler_rocks'
 gem 'nokogiri'
 gem 'hashie'
 gem 'thu_course'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,10 +125,6 @@ GEM
       sass (>= 3.2, < 3.5)
     concurrent-ruby (1.0.2)
     connection_pool (2.2.0)
-    crawler_rocks (0.0.6)
-      curb (~> 0.8, >= 0.8.8)
-      nokogiri (~> 1.6, >= 1.6.6.2)
-      rest-client (~> 2.0, >= 1.8.0)
     curb (0.9.3)
     debug_inspector (0.0.2)
     descendants_tracker (0.0.4)
@@ -460,7 +456,7 @@ DEPENDENCIES
   chronic
   coffee-rails (~> 4.1.0)
   compass-rails!
-  crawler_rocks
+  curb
   devise
   dotenv-rails
   factory_girl_rails (~> 4.0)

--- a/app/jobs/course_crawler_job.rb
+++ b/app/jobs/course_crawler_job.rb
@@ -9,7 +9,7 @@
 
 class CourseCrawlerJob
   include Sidekiq::Worker
-  include CourseCrawler::Mixin
+  include CourseCrawler::DateMixin
 
   sidekiq_options retry: false
 

--- a/app/models/crawler.rb
+++ b/app/models/crawler.rb
@@ -26,7 +26,7 @@
 
 
 class Crawler < ActiveRecord::Base
-  include CourseCrawler::Mixin
+  include CourseCrawler::DateMixin
 
   has_many :rufus_jobs
   has_many :courses, foreign_key: :organization_code, primary_key: :organization_code

--- a/lib/course_crawler/base.rb
+++ b/lib/course_crawler/base.rb
@@ -7,7 +7,7 @@ require 'thread'
 
 module CourseCrawler
   class Base
-    include Mixin
+    include DateMixin
 
     attr_reader   :year, :term
     attr_accessor :worker

--- a/lib/course_crawler/crawlers/cgu_course_crawler.rb
+++ b/lib/course_crawler/crawlers/cgu_course_crawler.rb
@@ -3,7 +3,7 @@
 
 module CourseCrawler::Crawlers
 class CguCourseCrawler < CourseCrawler::Base
-  include CrawlerRocks::DSL
+  include DSL
 
   DAYS = {
     "Mon" => 1,

--- a/lib/course_crawler/crawlers/cycu_course_crawler.rb
+++ b/lib/course_crawler/crawlers/cycu_course_crawler.rb
@@ -4,7 +4,7 @@
 #
 module CourseCrawler::Crawlers
 class CycuCourseCrawler < CourseCrawler::Base
-  include CrawlerRocks::DSL
+  include DSL
 
   PERIODS = {
     "特早" => 1,

--- a/lib/course_crawler/crawlers/fju_course_crawler.rb
+++ b/lib/course_crawler/crawlers/fju_course_crawler.rb
@@ -5,7 +5,7 @@
 
 module CourseCrawler::Crawlers
 class FjuCourseCrawler < CourseCrawler::Base
-  include CrawlerRocks::DSL
+  include DSL
 
   DAYS = {
     "一" => 1,

--- a/lib/course_crawler/crawlers/mcu_base_crawler.rb
+++ b/lib/course_crawler/crawlers/mcu_base_crawler.rb
@@ -5,7 +5,7 @@
 
 module CourseCrawler::Crawlers
 class McuBaseCrawler < CourseCrawler::Base
-  include CrawlerRocks::DSL
+  include DSL
 
   PERIODS = {
     "01" =>  1,

--- a/lib/course_crawler/crawlers/nccu_course_crawler.rb
+++ b/lib/course_crawler/crawlers/nccu_course_crawler.rb
@@ -3,7 +3,7 @@
 
 module CourseCrawler::Crawlers
 class NccuCourseCrawler < CourseCrawler::Base
-  include CrawlerRocks::DSL
+  include DSL
 
   DAYS = {
     "一" => 1,

--- a/lib/course_crawler/crawlers/nchu_course_crawler.rb
+++ b/lib/course_crawler/crawlers/nchu_course_crawler.rb
@@ -3,7 +3,7 @@
 
 module CourseCrawler::Crawlers
 class NchuCourseCrawler < CourseCrawler::Base
-  include CrawlerRocks::DSL
+  include DSL
 
   # PERIODS = {
   #   # Note:

--- a/lib/course_crawler/crawlers/ncku_course_crawler.rb
+++ b/lib/course_crawler/crawlers/ncku_course_crawler.rb
@@ -3,7 +3,7 @@
 
 module CourseCrawler::Crawlers
 class NckuCourseCrawler < CourseCrawler::Base
-  include CrawlerRocks::DSL
+  include DSL
 
   # PERIODS = {
   #   "0" => 1,

--- a/lib/course_crawler/crawlers/nctu_course_crawler/nctu_course.rb
+++ b/lib/course_crawler/crawlers/nctu_course_crawler/nctu_course.rb
@@ -1,6 +1,6 @@
 module CourseCrawler::Crawlers
 class NctuCourse
-  include CrawlerRocks::DSL
+  include DSL
 
   def initialize year: nil, term: nil
     @host = "http://timetable.nctu.edu.tw/"

--- a/lib/course_crawler/crawlers/nsysu_course_crawler.rb
+++ b/lib/course_crawler/crawlers/nsysu_course_crawler.rb
@@ -5,7 +5,7 @@
 
 module CourseCrawler::Crawlers
 class NsysuCourseCrawler < CourseCrawler::Base
-  include CrawlerRocks::DSL
+  include DSL
 
   DAYS = %w(一 二 三 四 五 六 日)
 

--- a/lib/course_crawler/crawlers/nthu_course_crawler.rb
+++ b/lib/course_crawler/crawlers/nthu_course_crawler.rb
@@ -9,7 +9,7 @@ require 'tempfile'
 
 module CourseCrawler::Crawlers
 class NthuCourseCrawler < CourseCrawler::Base
-  include CrawlerRocks::DSL
+  include DSL
 
   DAYS = {
     "M" => 1,

--- a/lib/course_crawler/crawlers/ntpu_course_crawler.rb
+++ b/lib/course_crawler/crawlers/ntpu_course_crawler.rb
@@ -3,7 +3,7 @@
 
 module CourseCrawler::Crawlers
 class NtpuCourseCrawler < CourseCrawler::Base
-  include CrawlerRocks::DSL
+  include DSL
 
   DAYS = {
     "一" => 1,

--- a/lib/course_crawler/crawlers/ntu_course_crawler.rb
+++ b/lib/course_crawler/crawlers/ntu_course_crawler.rb
@@ -4,7 +4,7 @@
 module CourseCrawler::Crawlers
   class NtuCourseCrawler < CourseCrawler::Base
 
-    include CrawlerRocks::DSL
+    include DSL
 
     DAYS = {
       "一" => 1,

--- a/lib/course_crawler/crawlers/tku_course_crawler.rb
+++ b/lib/course_crawler/crawlers/tku_course_crawler.rb
@@ -6,7 +6,7 @@ require 'capybara/poltergeist'
 
 module CourseCrawler::Crawlers
 class TkuCourseCrawler < CourseCrawler::Base
-  include CrawlerRocks::DSL
+  include DSL
   include Capybara::DSL
 
   DAYS = {

--- a/lib/course_crawler/crawlers/ttu_course_crawler.rb
+++ b/lib/course_crawler/crawlers/ttu_course_crawler.rb
@@ -2,7 +2,7 @@ require_relative './ttu_course_crawler/ttu_code'
 
 module CourseCrawler::Crawlers
 class TtuCourseCrawler < CourseCrawler::Base
-  include CrawlerRocks::DSL
+  include DSL
   include TtuCode
 
   DAYS = [6, 5, 4, 3, 2, 1]

--- a/lib/course_crawler/crawlers/usc_course_crawler.rb
+++ b/lib/course_crawler/crawlers/usc_course_crawler.rb
@@ -3,7 +3,7 @@
 
 module CourseCrawler::Crawlers
 class UscCourseCrawler < CourseCrawler::Base
-  include CrawlerRocks::DSL
+  include DSL
 
   DAYS = {
     "一" => 1,

--- a/lib/course_crawler/crawlers/usckh_course_crawler.rb
+++ b/lib/course_crawler/crawlers/usckh_course_crawler.rb
@@ -3,7 +3,7 @@
 
 module CourseCrawler::Crawlers
 class UsckhCourseCrawler < CourseCrawler::Base
-  include CrawlerRocks::DSL
+  include DSL
 
   DAYS = {
     "一" => 1,

--- a/lib/course_crawler/crawlers/yzu_course_crawler.rb
+++ b/lib/course_crawler/crawlers/yzu_course_crawler.rb
@@ -3,7 +3,7 @@
 
 module CourseCrawler::Crawlers
 class YzuCourseCrawler < CourseCrawler::Base
-  include CrawlerRocks::DSL
+  include DSL
 
   def initialize year: current_year, term: current_term, update_progress: nil, after_each: nil, params: nil
     @url = "https://portal.yzu.edu.tw/cosSelect/index.aspx?Lang=TW&D=G"

--- a/lib/course_crawler/date_mixin.rb
+++ b/lib/course_crawler/date_mixin.rb
@@ -1,5 +1,5 @@
 module CourseCrawler
-  module Mixin
+  module DateMixin
     def self.included(base)
       base.include(InstanceMethods)
     end

--- a/lib/course_crawler/dsl.rb
+++ b/lib/course_crawler/dsl.rb
@@ -1,0 +1,59 @@
+# a set of useful helper when writing course crawler
+module CourseCrawler
+  module DSL
+    attr_reader :current_url, :html
+
+    def setup
+      @cookies = nil
+    end
+
+    def visit(url)
+      handle_response(RestClient.get(url))
+      @current_url = url
+    end
+
+    def submit(submit_name = nil, form_data = {})
+      submit_selector = "input[type=\"submit\"][value=\"#{submit_name}\"]"
+
+      post_hash = case submit_name
+                  when nil
+                    get_view_state.merge(form_data)
+                  else
+                    Hash[@doc.css(submit_selector).map { |node| [node[:name], node[:value]] }].merge(get_view_state).merge(form_data)
+                  end
+
+      post_path = @doc.css(submit_selector).xpath('ancestor::form[1]//@action')[0].value
+
+      uri = URI.parse(@current_url)
+
+      post_path = case post_path[0]
+                  when '/'
+                    "#{uri.scheme}://#{uri.host}/"
+                  else
+                    URI.join("#{File.dirname(uri.to_s)}/", post_path).to_s
+                  end
+
+      post(post_path, post_hash)
+    end
+
+    def post(url, opt = {})
+      handle_response(RestClient.post(url, opt.merge(cookies: @cookies)))
+      @current_url = url
+    end
+
+    def get_view_state
+      Hash[
+        @doc.css('input[type="hidden"]').map { |input| [input[:name], input[:value]] }
+      ]
+    end
+
+    private
+
+    def handle_response(response)
+      @doc  = Nokogiri::HTML(response.force_encoding(response.encoding))
+      @html = response
+
+      @cookies ||= response.cookies
+    end
+  end
+end


### PR DESCRIPTION
### Redmine

https://redmine.colorgy.io/issues/428

### Changes

* `nctu_course.rb` `ttu_course_crawler.rb` `usc_course_crawler.rb` `usckh_course_crawler.rb` 轉換縮排
* 把 crawler_rocks 搬到 `lib/course_crawler/dsl.rb`，因為 gem 也寫的不是很好，還是不要過早封裝好了 XDD
* `DSL` 可以直接以下面的方式引用：

```ruby
include CourseCrawler::DSL
```
